### PR TITLE
proposal - simplify alert model

### DIFF
--- a/mode-apis-base/src/alertingModels.ts
+++ b/mode-apis-base/src/alertingModels.ts
@@ -226,38 +226,6 @@ export enum AlertState {
     INEFFECTIVE = 4,
 }
 
-
-export interface AlertEvaluation {
-    // Snapshot of an AlertCondition taken when it is evaluated.
-    readonly condition: AlertCondition;
-    readonly description: string;
-    readonly entityId: string;
-    readonly severity: AlertSeverity;
-}
-
-
-export interface MetricsAlertEvaluation extends AlertEvaluation {
-    readonly condition: MetricsAlertCondition;
-
-    // A metric is determined by entityClass, metricsDefinitionId and metricName
-    readonly entityClass: string;
-    readonly metricsDefinitionId: string;
-    readonly metricName: string;
-
-    // beginTime and endTime represent the time range against which the alert condition is evaluated
-    readonly beginTime: string;
-    readonly endTime: string;
-}
-
-
-export interface MetricsThresholdAlertEvaluation extends MetricsAlertEvaluation {
-    readonly condition: MetricsThresholdAlertCondition;
-
-    // the value that is evaluated against a condition when the condition is bleached.
-    readonly evaluatedValue: number;
-}
-
-
 export interface Alert {
     readonly id: string;
 
@@ -267,11 +235,26 @@ export interface Alert {
     // ALERTING -> RECOVERED or INEFFECTIVE or OBSOLETE
     readonly state: AlertState;
 
-    readonly evaluation: AlertEvaluation;
     readonly invocationTimestamp: string;
     readonly recoveryTimestamp?: string;
 }
 
+export interface MetricsAlert extends Alert {
+    readonly condition: MetricsHeartbeatAlertCondition | MetricsThresholdAlertCondition;
+
+    // A metric is determined by entityClass, metricsDefinitionId and metricName
+    readonly entityClass: string;
+    readonly metricsDefinitionId: string;
+    readonly metricName: string;
+}
+
+export interface MetricsThresholdAlert extends Alert {
+    readonly condition: MetricsThresholdAlertCondition;
+}
+
+export interface MetricsThresholdHeartbeat extends Alert {
+    readonly condition: MetricsThresholdAlertCondition;
+}
 
 /**
  * The filter options that the Fetch alerts API support

--- a/mode-apis-base/src/alertingModels.ts
+++ b/mode-apis-base/src/alertingModels.ts
@@ -239,8 +239,8 @@ export interface Alert {
     readonly recoveryTimestamp?: string;
 }
 
-export interface MetricsAlert extends Alert {
-    readonly condition: MetricsHeartbeatAlertCondition | MetricsThresholdAlertCondition;
+export interface MetricAlert extends Alert {
+    readonly condition: MetricsAlertCondition;
 
     // A metric is determined by entityClass, metricsDefinitionId and metricName
     readonly entityClass: string;
@@ -248,12 +248,12 @@ export interface MetricsAlert extends Alert {
     readonly metricName: string;
 }
 
-export interface MetricsThresholdAlert extends Alert {
+export interface MetricThresholdAlert extends MetricAlert {
     readonly condition: MetricsThresholdAlertCondition;
 }
 
-export interface MetricsThresholdHeartbeat extends Alert {
-    readonly condition: MetricsThresholdAlertCondition;
+export interface MetricHeartbeatAlert extends MetricAlert {
+    readonly condition: MetricsHeartbeatAlertCondition;
 }
 
 /**

--- a/mode-apis-base/src/alertingModels.ts
+++ b/mode-apis-base/src/alertingModels.ts
@@ -235,6 +235,10 @@ export interface Alert {
     // ALERTING -> RECOVERED or INEFFECTIVE or OBSOLETE
     readonly state: AlertState;
 
+    readonly entityId: string;
+    readonly description: string;
+    readonly severity: AlertSeverity;
+
     readonly invocationTimestamp: string;
     readonly recoveryTimestamp?: string;
 }

--- a/mode-apis-base/src/alertingModels.ts
+++ b/mode-apis-base/src/alertingModels.ts
@@ -229,6 +229,8 @@ export enum AlertState {
 export interface Alert {
     readonly id: string;
 
+    readonly condition: AlertCondition;
+
     readonly projectId: number;
 
     // Alert Status can transition in the following manner:


### PR DESCRIPTION
The purpose of this PR is following:

* Abolish AlertEvaluation interface.
* All "Alert" variants are represented by inheriting Alert interface.
* And, by removing beginTime, endTime and evaluatedValue fields, the metrics related alerts data structures are simplified.

The reasons for this change is the following:

* Alert is stateful object that's a consequence of a series of "alert rule evaluations".
Thus, it's counter intuitive, if an alert can only have single "evaluation" ( technically, one alert can consists of multiple alert rule evaluation)
* So, I thought it's much simpler and easy to understand the what alert without concept of Evaluation until we actually come up with the necessity how we want to use each evaluation result history in an alert.
* By the same reason, `beginTime`, `endTime` and `evaluatedValue` are removed.
* Actually, `beginTime` and `endTime` can be calculated by the information of alert.invocationTime and alert.condition information.
* `evaluatedValue` is more confusing, because it's not so obvious when this value is created. (e.g. we don't know if it is calculated when an alert is first created or it is created in the latest alert rule evaluation)