### PR TITLE
Alerting - add Event as an Alert Recipient type

### DIFF
--- a/mode-apis-base/src/alertingModels.ts
+++ b/mode-apis-base/src/alertingModels.ts
@@ -171,7 +171,8 @@ export interface AlertMessageTemplate {
 }
 
 export enum AlertRecipientType {
-    EMAIL = 'email'
+    EMAIL = 'email',
+    EVENT = 'event',
 }
 
 export interface AlertRecipient {
@@ -183,6 +184,11 @@ export interface AlertRecipientEmail extends AlertRecipient {
     readonly email: string;
 }
 
+export interface AlertRecipientEvent extends AlertRecipient {
+    readonly recipientType: AlertRecipientType.EVENT;
+    readonly eventType: string;
+}
+
 /**
  * Type guard to check if an object is an AlertRecipientEmail
  */
@@ -191,6 +197,14 @@ export const isEmailAlertRecipient = (obj: unknown): obj is AlertRecipientEmail 
     return recipient.recipientType === AlertRecipientType.EMAIL;
 };
 
+
+/**
+ * Type guard to check if an object is an AlertRecipientEvent
+ */
+ export const isEventAlertRecipient = (obj: unknown): obj is AlertRecipientEvent => {
+    const recipient = obj as AlertRecipientEvent;
+    return recipient.recipientType === AlertRecipientType.EVENT;
+};
 
 // We may want to have more various recipient types in the future.
 //


### PR DESCRIPTION
# About

This PR attempts to support MODE Event as an Alert Recipient Type.
The API client can specify the "event type" of MODE Events propagated when Alerts are invoked.

# Note

The backend supporting this feature will be released in the near future.