### PR TITLE
update entity interfaces

### DIFF
--- a/mode-apis-base/package.json
+++ b/mode-apis-base/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@moderepo/mode-apis-base",
-    "version": "0.2.10",
+    "version": "0.2.11",
     "description": "Classes, Models, and utils for all MODE apis",
     "scripts": {
         "build": "tsc"

--- a/mode-apis-base/src/entityModels.ts
+++ b/mode-apis-base/src/entityModels.ts
@@ -475,8 +475,8 @@ export interface FetchEntityFilters {
     readonly recursive?: boolean | undefined;
     readonly attributesQuery?: string | undefined;
 
-    // To have the back end sort the results by the specified "sortBy" (attribute name) in the specified "sortOrder"
-    readonly sortBy?: string;
+    // To have the back end sort the results by the specified "sortField" (attribute name) in the specified "sortOrder"
+    readonly sortField?: string;
     readonly sortOrder?: SortOrder;
 }
 

--- a/mode-apis-base/src/entityModels.ts
+++ b/mode-apis-base/src/entityModels.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 import {
-    SmartModuleType, TimeSeriesAggregation,
+    SmartModuleType, SortOrder, TimeSeriesAggregation,
 } from '.';
 
 
@@ -343,6 +343,10 @@ export interface EntityAttributeParam<ValueType extends EntityAttributeValueType
     readonly min?: number | undefined;
     readonly max?: number | undefined;
     readonly regex?: string | undefined;
+
+    // Whether or not the entity can be sorted by this attribute. This is OPTIONAL because existing entity classes' attribute schema
+    // might not have this settings. The default will be FALSE unless this attribute is specifically set to true.
+    readonly sortable?: boolean | undefined;
 }
 
 /**
@@ -414,6 +418,29 @@ export interface Entity {
         readonly metricsDefinitionId: string;
         readonly metricsId: string;
     }[] | undefined;
+
+    /**
+     * The summary of the entity instance's descendants. It is a map of the descendants' entityClass to the number of instances for that class. e.g.
+     *      entityInstance: {
+     *          entityId: "customer_1"
+     *          entityClass: "customer",
+     *          homeId: 1234,
+     *          ...
+     *          summary: {
+     *              site: 3,
+     *              control_server: 5,
+     *              ruber_3000: 58,
+     *          }
+     *      }
+     *
+     * Base on the data above. the "customer_1" has
+     *      - 3 entity instances of class "site"
+     *      - 5 entity instances of class "control_server"
+     *      - 58 entity instances of class "ruber_3000"
+     */
+    readonly summary?: {
+        readonly [entityClass: string]: number | undefined;
+    } | undefined;
 }
 
 /**
@@ -442,7 +469,15 @@ export interface FetchEntityFilters {
     // An comma separated list of entity classes
     readonly entityClasses?: string | undefined;
     readonly parentId?: string | null | undefined;
+    // To tell the backend whether or not to return only the DIRECT children or includes all descendants.
+    // By default, the back end will only include the entity instances that are direct children of the specified "parentId". If this flag
+    // is set to true, the back end will also includes children, grandchildren, great grandchildren, etc... of the "parentId"
+    readonly recursive?: boolean | undefined;
     readonly attributesQuery?: string | undefined;
+
+    // To have the back end sort the results by the specified "sortBy" (attribute name) in the specified "sortOrder"
+    readonly sortBy?: string;
+    readonly sortOrder?: SortOrder;
 }
 
 

--- a/mode-apis-base/src/entityModels.ts
+++ b/mode-apis-base/src/entityModels.ts
@@ -343,10 +343,6 @@ export interface EntityAttributeParam<ValueType extends EntityAttributeValueType
     readonly min?: number | undefined;
     readonly max?: number | undefined;
     readonly regex?: string | undefined;
-
-    // Whether or not the entity can be sorted by this attribute. This is OPTIONAL because existing entity classes' attribute schema
-    // might not have this settings. The default will be FALSE unless this attribute is specifically set to true.
-    readonly sortable?: boolean | undefined;
 }
 
 /**
@@ -420,13 +416,13 @@ export interface Entity {
     }[] | undefined;
 
     /**
-     * The summary of the entity instance's descendants. It is a map of the descendants' entityClass to the number of instances for that class. e.g.
+     * The counts of the entity instance's descendants. It is a map of the descendants' entityClass to the number of instances for that class. e.g.
      *      entityInstance: {
      *          entityId: "customer_1"
      *          entityClass: "customer",
      *          homeId: 1234,
      *          ...
-     *          summary: {
+     *          descendantCounts: {
      *              site: 3,
      *              control_server: 5,
      *              ruber_3000: 58,
@@ -438,7 +434,7 @@ export interface Entity {
      *      - 5 entity instances of class "control_server"
      *      - 58 entity instances of class "ruber_3000"
      */
-    readonly summary?: {
+    readonly descendantCounts?: {
         readonly [entityClass: string]: number | undefined;
     } | undefined;
 }
@@ -456,6 +452,13 @@ export const isEntity = (obj: unknown): obj is Entity => {
          && (typeof object.timeZone === 'string' && object.timeZone.length > 0)
          && (isEntityDisplaySettings(object.displaySettings));
 };
+
+
+export enum EntitySortFieldType {
+    BASIC = 'basic',
+    ATTRIBUTES = 'attributes',
+    DESCENDANT_COUNTS = 'descendantCounts',
+}
 
 
 // Interface for Entity filter options when calling GET entities API
@@ -476,8 +479,12 @@ export interface FetchEntityFilters {
     readonly attributesQuery?: string | undefined;
 
     // To have the back end sort the results by the specified "sortField" (attribute name) in the specified "sortOrder"
-    readonly sortField?: string;
-    readonly sortOrder?: SortOrder;
+    // "sortField" can be the name of an entity's basic attributes e.g. "entityClass", "entityId", "homeId", etc...
+    // "sortField" can also be the name of an entity's custom attribute name or descendant counts. However, if sortField IS NOT an entity's
+    // basic attribute, the caller MUST provide the field type
+    readonly sortField?: string | undefined;
+    readonly sortFieldType?: EntitySortFieldType.ATTRIBUTES | EntitySortFieldType.DESCENDANT_COUNTS | undefined;
+    readonly sortOrder?: SortOrder | undefined;
 }
 
 

--- a/mode-apis/package-lock.json
+++ b/mode-apis/package-lock.json
@@ -1,13 +1,13 @@
 {
     "name": "@moderepo/mode-apis",
-    "version": "0.3.10",
+    "version": "0.3.11",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
         "@moderepo/mode-apis-base": {
-            "version": "0.2.10",
-            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-apis-base/0.2.10/a8a9dc123102ab9ba60e008b9ba1c238616fc8f5",
-            "integrity": "sha512-fLsH06/zOvo7MX0NCyygQI5FiI8Ht12FJQgbb7/riWck7wkpM1NX/aCvs/7jbBEvZDK+3pDZA45bGVSQpVTQUQ==",
+            "version": "0.2.11",
+            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-apis-base/0.2.11/e9bc4175a892c0c9e1d357c4c1954e1c5943cd6b",
+            "integrity": "sha512-nECZLSUblYunoDxvKqexE7En7XBSl2UWPFYHOfCteyPU6h3FZF8WeYvtNJB5uyEsxvZ/hAozwYlNTtdFWXoLTw==",
             "requires": {
                 "axios": "^0.24.0"
             }

--- a/mode-apis/package.json
+++ b/mode-apis/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@moderepo/mode-apis",
-    "version": "0.3.11",
+    "version": "0.3.12",
     "description": "MODE's apis for end-user apps",
     "scripts": {
         "build": "tsc"
@@ -29,7 +29,7 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "dependencies": {
-        "@moderepo/mode-apis-base": "^0.2.10",
+        "@moderepo/mode-apis-base": "^0.2.11",
         "axios": "^0.24.0"
     },
     "devDependencies": {

--- a/mode-apis/src/appAPI.ts
+++ b/mode-apis/src/appAPI.ts
@@ -1193,7 +1193,18 @@ export class AppAPI extends BaseAPI {
      * @returns
      */
     public async getEntities (projectId: number, filters: FetchEntityFilters): Promise<PaginationDataSet<Entity>> {
-        const response = await this.sendRequest(RequestMethod.GET, `/projects/${projectId}/entities`, filters);
+        // Because front end separate "filters.sortBy" and "filters.sortOrder" while the back end expect both of them to be in 1 param,
+        // we will need to modify the "filters" object. We will make a copy of the "filters" object and then modify the "sortBy" value
+        // by combining the "sortBy" with "sortOrder". And then delete the "sortOrder" since we don't need to send it to the back end.
+        const modifiedFilters = {
+            ...filters,                                    // make a copy of the "filters" object
+            sortBy: filters?.sortBy && filters?.sortOrder  // sortBy and sortOrder BOTH need to be provided or none but can't have 1 only.
+                ? `${filters.sortBy}:${filters.sortOrder}` // concatenate filters.sortBy and filters.sortOrder with ":"
+                : undefined,
+        };
+        delete modifiedFilters.sortOrder;
+
+        const response = await this.sendRequest(RequestMethod.GET, `/projects/${projectId}/entities`, modifiedFilters);
 
         if (response.data instanceof Array) {
             const range = parseDataRange(response.headers[DATA_RANGE_HEADER_KEY]);

--- a/mode-apis/src/appAPI.ts
+++ b/mode-apis/src/appAPI.ts
@@ -1197,9 +1197,9 @@ export class AppAPI extends BaseAPI {
         // we will need to modify the "filters" object. We will make a copy of the "filters" object and then modify the "sortBy" value
         // by combining the "sortBy" with "sortOrder". And then delete the "sortOrder" since we don't need to send it to the back end.
         const modifiedFilters = {
-            ...filters,                                    // make a copy of the "filters" object
-            sortBy: filters?.sortBy && filters?.sortOrder  // sortBy and sortOrder BOTH need to be provided or none but can't have 1 only.
-                ? `${filters.sortBy}:${filters.sortOrder}` // concatenate filters.sortBy and filters.sortOrder with ":"
+            ...filters,                                         // make a copy of the "filters" object
+            sortBy: filters?.sortField && filters?.sortOrder    // sortField and sortOrder BOTH need to be provided or none but can't have 1 only.
+                ? `${filters.sortField}:${filters.sortOrder}`   // concatenate filters.sortField and filters.sortOrder with ":"
                 : undefined,
         };
         delete modifiedFilters.sortOrder;

--- a/mode-app-components/package-lock.json
+++ b/mode-app-components/package-lock.json
@@ -2110,51 +2110,51 @@
             }
         },
         "@moderepo/mode-apis": {
-            "version": "0.3.11",
-            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-apis/0.3.11/13c376dd374f1c7e7a8df0d83158e98349b3e59d",
-            "integrity": "sha512-EcHOmj1wy7aX1iZob0HzNPfBMJwfWgsBu+dYse4mW4WjcnEL1PWB4A4beu4R2I3ewRFqF5Xu58aLSshkGh17Ew==",
+            "version": "0.3.12",
+            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-apis/0.3.12/ddb8ead41bfe6b0f2898b278a484f6d19e3b4f83",
+            "integrity": "sha512-hp300/EjJLeudWx/VzDLvJY8MKqZEiEYts4+uPhl/Vm7rob/gvq0OSlRvmWJdvsdMkhpiuJBvTpT66fo2cPEWA==",
             "requires": {
-                "@moderepo/mode-apis-base": "^0.2.10",
+                "@moderepo/mode-apis-base": "^0.2.11",
                 "axios": "^0.24.0"
             }
         },
         "@moderepo/mode-apis-base": {
-            "version": "0.2.10",
-            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-apis-base/0.2.10/a8a9dc123102ab9ba60e008b9ba1c238616fc8f5",
-            "integrity": "sha512-fLsH06/zOvo7MX0NCyygQI5FiI8Ht12FJQgbb7/riWck7wkpM1NX/aCvs/7jbBEvZDK+3pDZA45bGVSQpVTQUQ==",
+            "version": "0.2.11",
+            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-apis-base/0.2.11/e9bc4175a892c0c9e1d357c4c1954e1c5943cd6b",
+            "integrity": "sha512-nECZLSUblYunoDxvKqexE7En7XBSl2UWPFYHOfCteyPU6h3FZF8WeYvtNJB5uyEsxvZ/hAozwYlNTtdFWXoLTw==",
             "requires": {
                 "axios": "^0.24.0"
             }
         },
         "@moderepo/mode-data-state-base": {
-            "version": "0.2.8",
-            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-data-state-base/0.2.8/b13e4d90cc2ad4589549c3269b08d6daf910bda4",
-            "integrity": "sha512-BhNtrytvocDM4CEKRv/RHOSjtj60QB4wPH/tGUVJRErEMfyBPYzqxSd7YWwJwJe5COJq9fvquOHx0nHxtpPH6g==",
+            "version": "0.2.9",
+            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-data-state-base/0.2.9/d48d52f02a16fa32c8e50e3d47d502c32e33bf58",
+            "integrity": "sha512-VTokF+5CNitUJZaCjo8TJHauKYKmMZ2tBSmd3w1j3tlqDuqN2XYLOmnSoON8ZbnFFbsPHpjqu4YMfOmbMmmHAw==",
             "requires": {
-                "@moderepo/mode-apis-base": "^0.2.10",
+                "@moderepo/mode-apis-base": "^0.2.11",
                 "immer": "^9.0.7",
                 "reselect": "^4.1.5"
             }
         },
         "@moderepo/mode-data-state-robot-cloud": {
-            "version": "0.2.9",
-            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-data-state-robot-cloud/0.2.9/cb426fc1fc24523a3c70d29e991f400c0b4d93c1",
-            "integrity": "sha512-1JMJD3iOVpMTO1Q9Egjb194D8miKi5eTkD0uaEt1dBftfdHGwg0yuJz8y96NWIUdN6Ztm8AflQgrEBMV/N5byg==",
+            "version": "0.2.10",
+            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-data-state-robot-cloud/0.2.10/ceff9b108002ebeae5cd398c6b05c44c1871e2dd",
+            "integrity": "sha512-WErsLoyGNpR8s69nYTS8XEMEepz9jEV/4+oYLQg6+N0VoC54+rslIKIp8BDLVEm+5oPJFrQRYiICwDdjYgATEA==",
             "requires": {
-                "@moderepo/mode-apis": "^0.3.11",
-                "@moderepo/mode-data-state-base": "^0.2.8",
+                "@moderepo/mode-apis": "^0.3.12",
+                "@moderepo/mode-data-state-base": "^0.2.9",
                 "immer": "^9.0.7",
                 "re-reselect": "^4.0.0",
                 "reselect": "^4.1.5"
             }
         },
         "@moderepo/mode-data-state-user-app": {
-            "version": "0.2.9",
-            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-data-state-user-app/0.2.9/ae66ff9338691669567e31e2736b26ad108be1d0",
-            "integrity": "sha512-4aunldg1hBNotcmxwZ28IrwaBcQ6MAzfDRNCCpBqHGv8kxmE1pJxPHVyczgCOspYGkLVn0RXK/GKB/8mgw7thg==",
+            "version": "0.2.10",
+            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-data-state-user-app/0.2.10/b7d09338f4738a14bc6285624355524db8b3d1d5",
+            "integrity": "sha512-qGt+skJfpJxeuXxJQ1no6XBp5LqvEWyh9dKdLz0XP5NBvUdEqtUL4pLuu1ZqQOfx8qA/iEJTwyyWEuMDqS7N5w==",
             "requires": {
-                "@moderepo/mode-apis": "^0.3.11",
-                "@moderepo/mode-data-state-base": "^0.2.8",
+                "@moderepo/mode-apis": "^0.3.12",
+                "@moderepo/mode-data-state-base": "^0.2.9",
                 "immer": "^9.0.7",
                 "re-reselect": "^4.0.0",
                 "reselect": "^4.1.5"

--- a/mode-app-components/package.json
+++ b/mode-app-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@moderepo/mode-app-components",
-    "version": "0.2.18",
+    "version": "0.2.20",
     "description": "Components that can be used for implementing MODE applications",
     "scripts": {
         "build": "tsc"
@@ -31,9 +31,9 @@
         "@material-ui/icons": "^4.11.2",
         "@material-ui/lab": "^4.0.0-alpha.60",
         "@material-ui/pickers": "^3.3.10",
-        "@moderepo/mode-apis": "^0.3.11",
-        "@moderepo/mode-data-state-robot-cloud": "^0.2.9",
-        "@moderepo/mode-data-state-user-app": "^0.2.9",
+        "@moderepo/mode-apis": "^0.3.12",
+        "@moderepo/mode-data-state-robot-cloud": "^0.2.10",
+        "@moderepo/mode-data-state-user-app": "^0.2.10",
         "@moderepo/mode-ui-state": "^0.1.5",
         "@types/react": "^17.0.38",
         "@types/react-dom": "^17.0.11",
@@ -64,9 +64,9 @@
         "@material-ui/icons": ">=4.11.2",
         "react-router-dom": ">=5.2.0",
         "use-debounce": ">=7.0.1",
-        "@moderepo/mode-apis": ">=0.3.11",
-        "@moderepo/mode-data-state-robot-cloud": "0.2.9",
-        "@moderepo/mode-data-state-user-app": "0.2.9",
+        "@moderepo/mode-apis": ">=0.3.12",
+        "@moderepo/mode-data-state-robot-cloud": "0.2.10",
+        "@moderepo/mode-data-state-user-app": "0.2.10",
         "@moderepo/mode-ui-state": ">=0.1.5"
     }
 }

--- a/mode-app-components/src/components/generic/GenericTableComp.tsx
+++ b/mode-app-components/src/components/generic/GenericTableComp.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import {
-    Paper, Table, TableRow, TableCell, TableHead, TableBody, makeStyles,
+    Paper, Table, TableRow, TableCell, TableHead, TableBody, makeStyles, Theme,
 } from '@material-ui/core';
 import clsx from 'clsx';
 import {
-    BaseListCompDataItem, BaseListCompField, BaseListCompFieldsSet, BaseListCompFieldsSettings, BaseListCompProps, CompPanelHeader,
+    BaseListCompDataItem, BaseListCompField, BaseListCompFieldsSet, BaseListCompFieldsSettings, BaseListCompProps, BLANK_IMAGE, CompPanelHeader,
     createHeaderColumn, createPreviewItemCell, createRemoveItemCell, useModePanelStyle, useModeTableStyle,
 } from '../..';
 
 
-const useStyle = makeStyles(() => {
+const useStyle = makeStyles((theme: Theme) => {
     return {
 
         panelHeaderIcon: {
@@ -29,6 +29,28 @@ const useStyle = makeStyles(() => {
 
         tableCol: {
             textAlign: 'left',
+
+            '&.image-col': {
+                textAlign : 'center',
+                '& .image': {
+                    width    : 100,
+                    height   : 75,
+                    objectFit: 'cover',
+                    boxShadow: theme.shadows[2],
+                },
+            },
+
+            '&.text-align-center': {
+                textAlign: 'center',
+            },
+
+            '&.text-align-left': {
+                textAlign: 'left',
+            },
+            
+            '&.text-align-right': {
+                textAlign: 'right',
+            },
         },
     };
 }, {
@@ -36,9 +58,16 @@ const useStyle = makeStyles(() => {
 });
 
 
+// GenericTableListCompField settings is just a BaseListCompField with an additional attribute "valueType" which can be used for customizing
+// style for each field.
+export interface GenericTableListCompField extends BaseListCompField {
+    readonly valueType?: 'string' | 'image' | undefined;
+    readonly textAlign?: 'left' | 'right' | 'center' | undefined;
+}
+
 
 export interface GenericTableCompFieldsSet extends BaseListCompFieldsSet {
-    readonly [fieldName: string]: BaseListCompField | undefined;
+    readonly [fieldName: string]: GenericTableListCompField | undefined;
 }
 
 
@@ -81,9 +110,14 @@ export const GenericTableComp = <T extends unknown>(props: GenericTableCompProps
                                     }).map((fieldName: string) => {
                                         const field = props.fieldsSettings.fields[fieldName];
                                         if (field && !field.hidden) {
+                                            const isImage = props.fieldsSettings.fields[fieldName]?.valueType === 'image';
+                                            const textAlign = props.fieldsSettings.fields[fieldName]?.textAlign;
                                             return createHeaderColumn(
                                                 props.fieldsSettings, fieldName, field,
-                                                `${tableClasses.tableCol} ${classes.tableCol} ${fieldName}-col`,
+                                                clsx(
+                                                    tableClasses.tableCol, classes.tableCol, `${fieldName}-col`,
+                                                    isImage && 'image-col', textAlign && `text-align-${textAlign}`,
+                                                ),
                                             );
                                         }
                                         return <></>;
@@ -130,14 +164,31 @@ export const GenericTableComp = <T extends unknown>(props: GenericTableCompProps
                                                  * Handle all the other fields that don't have special UI. These are the fields that
                                                  * display dataItem.displayValue as plain text
                                                  */
-                                                if (props.fieldsSettings.fields[fieldName]
-                                                        && !(props.fieldsSettings.fields[fieldName] as BaseListCompField).hidden) {
+                                                if (props.fieldsSettings.fields[fieldName] && !props.fieldsSettings.fields[fieldName]?.hidden) {
+                                                    const isImage = props.fieldsSettings.fields[fieldName]?.valueType === 'image';
+                                                    const value = dataItem.displayValue?.[fieldName] ?? dataItem.actualValue[fieldName];
+                                                    const textAlign = props.fieldsSettings.fields[fieldName]?.textAlign;
                                                     return (
                                                         <TableCell
                                                             key={fieldName}
-                                                            className={clsx(tableClasses.tableCol, classes.tableCol, `${fieldName}-col`)}
+                                                            className={clsx(
+                                                                tableClasses.tableCol, classes.tableCol, `${fieldName}-col`, isImage && 'image-col',
+                                                                textAlign && `text-align-${textAlign}`,
+                                                            )}
                                                         >
-                                                            {(dataItem.displayValue?.[fieldName] ?? dataItem.actualValue[fieldName])?.toString()}
+                                                            {isImage ? (
+                                                                <>
+                                                                    {value && (
+                                                                        <img
+                                                                            className="image"
+                                                                            alt={value.toString()}
+                                                                            src={value}
+                                                                        />
+                                                                    )}
+                                                                </>
+                                                            ) : (
+                                                                value?.toString()
+                                                            )}
                                                         </TableCell>
                                                     );
                                                 }

--- a/mode-app-components/src/components/mode/timeSeriesComponents/TimeSeriesDataTable.tsx
+++ b/mode-app-components/src/components/mode/timeSeriesComponents/TimeSeriesDataTable.tsx
@@ -36,7 +36,8 @@ const useStyle = makeStyles(() => {
                 textAlign: 'left',
             },
             '&.spacer-col': {
-                width: '100%',
+                width  : '100%',
+                padding: 0,
             },
             '&.value-col': {
                 textAlign: 'center',

--- a/mode-app-components/src/utils/constants.ts
+++ b/mode-app-components/src/utils/constants.ts
@@ -104,3 +104,6 @@ export const AUTH_KEY_EXPIRATION_CHECK_FREQ_IN_MS: number = 30000;      // How f
 
 export const METRIC_VIEW_DEFAULT_TIME_RANGE = Time.DAY_IN_MS;           // The default time range in the time series metric view
 export const METRIC_VIEW_MIN_TIME_RANGE = 30 * Time.MINUTE_IN_MS;       // The minimum time range the user can select from the date selector
+
+
+export const BLANK_IMAGE = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';

--- a/mode-data-state-base/package-lock.json
+++ b/mode-data-state-base/package-lock.json
@@ -1,13 +1,13 @@
 {
     "name": "@moderepo/mode-data-state-base",
-    "version": "0.2.7",
+    "version": "0.2.8",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
         "@moderepo/mode-apis-base": {
-            "version": "0.2.10",
-            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-apis-base/0.2.10/a8a9dc123102ab9ba60e008b9ba1c238616fc8f5",
-            "integrity": "sha512-fLsH06/zOvo7MX0NCyygQI5FiI8Ht12FJQgbb7/riWck7wkpM1NX/aCvs/7jbBEvZDK+3pDZA45bGVSQpVTQUQ==",
+            "version": "0.2.11",
+            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-apis-base/0.2.11/e9bc4175a892c0c9e1d357c4c1954e1c5943cd6b",
+            "integrity": "sha512-nECZLSUblYunoDxvKqexE7En7XBSl2UWPFYHOfCteyPU6h3FZF8WeYvtNJB5uyEsxvZ/hAozwYlNTtdFWXoLTw==",
             "requires": {
                 "axios": "^0.24.0"
             }

--- a/mode-data-state-base/package.json
+++ b/mode-data-state-base/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@moderepo/mode-data-state-base",
-    "version": "0.2.8",
+    "version": "0.2.9",
     "description": "Module for managing Data states globally e.g. Users, Homes, Devices, etc...",
     "scripts": {
         "build": "tsc"
@@ -30,7 +30,7 @@
     },
     "homepage": "https://github.com/moderepo/react-common-public#readme",
     "dependencies": {
-        "@moderepo/mode-apis-base": "^0.2.10",
+        "@moderepo/mode-apis-base": "^0.2.11",
         "immer": "^9.0.7",
         "reselect": "^4.1.5"
     },

--- a/mode-data-state-robot-cloud/package-lock.json
+++ b/mode-data-state-robot-cloud/package-lock.json
@@ -1,32 +1,32 @@
 {
     "name": "@moderepo/mode-data-state-robot-cloud",
-    "version": "0.2.8",
+    "version": "0.2.9",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
         "@moderepo/mode-apis": {
-            "version": "0.3.11",
-            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-apis/0.3.11/13c376dd374f1c7e7a8df0d83158e98349b3e59d",
-            "integrity": "sha512-EcHOmj1wy7aX1iZob0HzNPfBMJwfWgsBu+dYse4mW4WjcnEL1PWB4A4beu4R2I3ewRFqF5Xu58aLSshkGh17Ew==",
+            "version": "0.3.12",
+            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-apis/0.3.12/ddb8ead41bfe6b0f2898b278a484f6d19e3b4f83",
+            "integrity": "sha512-hp300/EjJLeudWx/VzDLvJY8MKqZEiEYts4+uPhl/Vm7rob/gvq0OSlRvmWJdvsdMkhpiuJBvTpT66fo2cPEWA==",
             "requires": {
-                "@moderepo/mode-apis-base": "^0.2.10",
+                "@moderepo/mode-apis-base": "^0.2.11",
                 "axios": "^0.24.0"
             }
         },
         "@moderepo/mode-apis-base": {
-            "version": "0.2.10",
-            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-apis-base/0.2.10/a8a9dc123102ab9ba60e008b9ba1c238616fc8f5",
-            "integrity": "sha512-fLsH06/zOvo7MX0NCyygQI5FiI8Ht12FJQgbb7/riWck7wkpM1NX/aCvs/7jbBEvZDK+3pDZA45bGVSQpVTQUQ==",
+            "version": "0.2.11",
+            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-apis-base/0.2.11/e9bc4175a892c0c9e1d357c4c1954e1c5943cd6b",
+            "integrity": "sha512-nECZLSUblYunoDxvKqexE7En7XBSl2UWPFYHOfCteyPU6h3FZF8WeYvtNJB5uyEsxvZ/hAozwYlNTtdFWXoLTw==",
             "requires": {
                 "axios": "^0.24.0"
             }
         },
         "@moderepo/mode-data-state-base": {
-            "version": "0.2.8",
-            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-data-state-base/0.2.8/b13e4d90cc2ad4589549c3269b08d6daf910bda4",
-            "integrity": "sha512-BhNtrytvocDM4CEKRv/RHOSjtj60QB4wPH/tGUVJRErEMfyBPYzqxSd7YWwJwJe5COJq9fvquOHx0nHxtpPH6g==",
+            "version": "0.2.9",
+            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-data-state-base/0.2.9/d48d52f02a16fa32c8e50e3d47d502c32e33bf58",
+            "integrity": "sha512-VTokF+5CNitUJZaCjo8TJHauKYKmMZ2tBSmd3w1j3tlqDuqN2XYLOmnSoON8ZbnFFbsPHpjqu4YMfOmbMmmHAw==",
             "requires": {
-                "@moderepo/mode-apis-base": "^0.2.10",
+                "@moderepo/mode-apis-base": "^0.2.11",
                 "immer": "^9.0.7",
                 "reselect": "^4.1.5"
             }

--- a/mode-data-state-robot-cloud/package.json
+++ b/mode-data-state-robot-cloud/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@moderepo/mode-data-state-robot-cloud",
-    "version": "0.2.9",
+    "version": "0.2.10",
     "description": "Module for managing Data states globally for mode ROBOT CLOUD applications",
     "scripts": {
         "build": "tsc"
@@ -30,8 +30,8 @@
     },
     "homepage": "https://github.com/moderepo/react-common-public#readme",
     "dependencies": {
-        "@moderepo/mode-apis": "^0.3.11",
-        "@moderepo/mode-data-state-base": "^0.2.8",
+        "@moderepo/mode-apis": "^0.3.12",
+        "@moderepo/mode-data-state-base": "^0.2.9",
         "immer": "^9.0.7",
         "re-reselect": "^4.0.0",
         "reselect": "^4.1.5"
@@ -45,6 +45,6 @@
     "peerDependencies": {
         "react": ">=17.0.2",
         "react-dom": ">=17.0.2",
-        "@moderepo/mode-apis": ">=0.3.11"
+        "@moderepo/mode-apis": ">=0.3.12"
     }
 }

--- a/mode-data-state-user-app/package-lock.json
+++ b/mode-data-state-user-app/package-lock.json
@@ -1,32 +1,32 @@
 {
     "name": "@moderepo/mode-data-state-user-app",
-    "version": "0.2.8",
+    "version": "0.2.9",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
         "@moderepo/mode-apis": {
-            "version": "0.3.11",
-            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-apis/0.3.11/13c376dd374f1c7e7a8df0d83158e98349b3e59d",
-            "integrity": "sha512-EcHOmj1wy7aX1iZob0HzNPfBMJwfWgsBu+dYse4mW4WjcnEL1PWB4A4beu4R2I3ewRFqF5Xu58aLSshkGh17Ew==",
+            "version": "0.3.12",
+            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-apis/0.3.12/ddb8ead41bfe6b0f2898b278a484f6d19e3b4f83",
+            "integrity": "sha512-hp300/EjJLeudWx/VzDLvJY8MKqZEiEYts4+uPhl/Vm7rob/gvq0OSlRvmWJdvsdMkhpiuJBvTpT66fo2cPEWA==",
             "requires": {
-                "@moderepo/mode-apis-base": "^0.2.10",
+                "@moderepo/mode-apis-base": "^0.2.11",
                 "axios": "^0.24.0"
             }
         },
         "@moderepo/mode-apis-base": {
-            "version": "0.2.10",
-            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-apis-base/0.2.10/a8a9dc123102ab9ba60e008b9ba1c238616fc8f5",
-            "integrity": "sha512-fLsH06/zOvo7MX0NCyygQI5FiI8Ht12FJQgbb7/riWck7wkpM1NX/aCvs/7jbBEvZDK+3pDZA45bGVSQpVTQUQ==",
+            "version": "0.2.11",
+            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-apis-base/0.2.11/e9bc4175a892c0c9e1d357c4c1954e1c5943cd6b",
+            "integrity": "sha512-nECZLSUblYunoDxvKqexE7En7XBSl2UWPFYHOfCteyPU6h3FZF8WeYvtNJB5uyEsxvZ/hAozwYlNTtdFWXoLTw==",
             "requires": {
                 "axios": "^0.24.0"
             }
         },
         "@moderepo/mode-data-state-base": {
-            "version": "0.2.8",
-            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-data-state-base/0.2.8/b13e4d90cc2ad4589549c3269b08d6daf910bda4",
-            "integrity": "sha512-BhNtrytvocDM4CEKRv/RHOSjtj60QB4wPH/tGUVJRErEMfyBPYzqxSd7YWwJwJe5COJq9fvquOHx0nHxtpPH6g==",
+            "version": "0.2.9",
+            "resolved": "https://npm.pkg.github.com/download/@moderepo/mode-data-state-base/0.2.9/d48d52f02a16fa32c8e50e3d47d502c32e33bf58",
+            "integrity": "sha512-VTokF+5CNitUJZaCjo8TJHauKYKmMZ2tBSmd3w1j3tlqDuqN2XYLOmnSoON8ZbnFFbsPHpjqu4YMfOmbMmmHAw==",
             "requires": {
-                "@moderepo/mode-apis-base": "^0.2.10",
+                "@moderepo/mode-apis-base": "^0.2.11",
                 "immer": "^9.0.7",
                 "reselect": "^4.1.5"
             }

--- a/mode-data-state-user-app/package.json
+++ b/mode-data-state-user-app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@moderepo/mode-data-state-user-app",
-    "version": "0.2.9",
+    "version": "0.2.10",
     "description": "Module for managing Data states globally for End-User apps",
     "scripts": {
         "build": "tsc"
@@ -30,8 +30,8 @@
     },
     "homepage": "https://github.com/moderepo/react-common-public#readme",
     "dependencies": {
-        "@moderepo/mode-apis": "^0.3.11",
-        "@moderepo/mode-data-state-base": "^0.2.8",
+        "@moderepo/mode-apis": "^0.3.12",
+        "@moderepo/mode-data-state-base": "^0.2.9",
         "immer": "^9.0.7",
         "re-reselect": "^4.0.0",
         "reselect": "^4.1.5"
@@ -45,6 +45,6 @@
     "peerDependencies": {
         "react": ">=17.0.2",
         "react-dom": ">=17.0.2",
-        "@moderepo/mode-apis": ">=0.3.11"
+        "@moderepo/mode-apis": ">=0.3.12"
     }
 }


### PR DESCRIPTION
# Update the Entity interfaces to support new features
- Add `sortable` option to the entity class attribute schema. Here is an example entity class's attributes' schema which has 4 attributes but only `serialNumber` and `modelNumber` are sortable.
  ```
  {
      "entityClass": "robot_ruber_3000",
      "displaySettings": {
          "name": "Ruber 3000",
          "description": "Delivery robot Ruber model 3000",
      },
      "metricsDefinitions": [
          ...
      ],
      "attributeSchema": [
          {
              "key": "serialNumber",
              "type": "string",
              "required": true,
              "sortable": true,
              "label": "Serial Number",
              "description": "Robot serial number"
          },
          {
              "key": "modelNumber",
              "type": "string",
              "required": false,
              "sortable": true,
              "label": "Model Number",
              "description": "The robot's model number"
          },
          {
              "key": "gps_lat",
              "type": "number",
              "required": false,
              "label": "GPS Latitude",
              "description": "Latitude value of the site GPS location"
          },
          {
              "key": "gps_lng",
              "type": "number",
              "required": false,
              "label": "GPS Longitude",
              "description": "Longitude value of the site GPS location"
          }
      ],
  }
  ```
- Add `summary` attribute to `Entity` instance interface. All entity instances can now have an optional attribute call `summary` which is a map of `entityClass => entityInstancesCount`. Here is an example list of Line entity instances that has `summary` data
  ```
  [
    {
        "entityId": "line-1",
        "projectId": 1367,
        "homeId": 2067,
        "parentId": "region_1",
        "entityClass": "line",
        "displaySettings": {
            "name": "...",
            "description": "..."
        },
        "summary": {
            "nozzle": 123,
            "head": 23,
            "machine": 4
        }
    },
    {
        "entityId": "line-2",
        "projectId": 1367,
        "homeId": 2067,
        "parentId": "region_1",
        "entityClass": "line",
        "displaySettings": {
            "name": "...",
            "description": "..."
        },
        "summary": {
            "head": 2,
            "machine": 343
        }
    },
    {
        "entityId": "line-3",
        "projectId": 1367,
        "homeId": 2067,
        "parentId": "region_1",
        "entityClass": "line",
        "displaySettings": {
            "name": "...",
            "description": "..."
        },
        "summary": {
            "machine": 12
        }
    },
    {
        "entityId": "line-4",
        "projectId": 1367,
        "homeId": 2067,
        "parentId": "region_1",
        "entityClass": "line",
        "displaySettings": {
            "name": "...",
            "description": "..."
        },
        "summary": {
            "nozzle": 13,
            "machine": 434
        }
    }
  ]
  ```

- Add `sortBy` param to the GET entities filters. So now when fetching entities, the front end can pass a `sortBy` param to the back end to have the back end sort the result by the specified param. For example this will ask the back end to return all entities and sort them by attribute name `serial_number` in `desc` order
  - https://dev.tinkermode.dev:7002/projects/1367/entities?limit=100&sortBy=serial_number:desc

- Add `recursive` param to the GET entities filters. So now when we call to fetch `descendants` of an entity instance, not just children. For example, this will call the back end to return all entities of class `ruber_3000` that are descendants of the customer with id `customer_1' AND sort the results by `serial_numer` in `desc` order
  - https://dev.tinkermode.dev:7002/projects/1367/entities?limit=100&entityClasses=ruber_3000&parentId=customer_1&sortBy=serial_number:desc
