### PR TITLE
Add date and date-time to EntityAttributeType

### DIFF
--- a/mode-apis-base/package.json
+++ b/mode-apis-base/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@moderepo/mode-apis-base",
-    "version": "0.2.11",
+    "version": "0.2.12",
     "description": "Classes, Models, and utils for all MODE apis",
     "scripts": {
         "build": "tsc"

--- a/mode-apis-base/src/entityModels.ts
+++ b/mode-apis-base/src/entityModels.ts
@@ -319,6 +319,8 @@ export enum EntityAttributeType {
     BOOLEAN = 'boolean',
     ARRAY = 'array',
     OBJECT = 'object',
+    DATE = 'date',
+    DATETIME = 'date-time',
 }
 
 

--- a/mode-apis/package.json
+++ b/mode-apis/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@moderepo/mode-apis",
-    "version": "0.3.17",
+    "version": "0.3.18",
     "description": "MODE's apis for end-user apps",
     "scripts": {
         "build": "tsc"
@@ -29,7 +29,7 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "dependencies": {
-        "@moderepo/mode-apis-base": "^0.2.11",
+        "@moderepo/mode-apis-base": "^0.2.12",
         "axios": "^0.24.0"
     },
     "devDependencies": {


### PR DESCRIPTION
`date` and `date-time` will be added to `AttributeType` at Backend.
These changes are needed on the Client API handling part.